### PR TITLE
Restore integration tests for Github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,28 +25,28 @@ jobs:
 # Integration tests temporarily disabled while token access issue is diagnosed
 ##############################################################################
 
-  # test:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: ./
-  #       name: "🚀 test github user workflow"
-  #       with:
-  #         path: ./
-  #         token: ${{ secrets.ACCESS_TOKEN }}
-  #         ref: ${{ github.event.pull_request.head.sha }}
-  #         repo: tremor-runtime
-  #         owner: tremor-rs
-  #         user: lelia
-  #     - uses: ./
-  #       name: "🌎 test github org workflow"
-  #       with:
-  #         path: ./
-  #         token: ${{ secrets.ACCESS_TOKEN }}
-  #         ref: ${{ github.event.pull_request.head.sha }}
-  #         licenseAllowlist: "0bsd\napache-2.0\nmit"
-  #         repo: roadie-backstage-plugins
-  #         owner: RoadieHQ
-  #         org: wayfair-contribs
-  #         user: lelia
-  #         addUser: true
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./
+        name: "🚀 test github user workflow"
+        with:
+          path: ./
+          token: ${{ secrets.DROWE_ACCESS_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          repo: tremor-runtime
+          owner: tremor-rs
+          user: lelia
+      - uses: ./
+        name: "🌎 test github org workflow"
+        with:
+          path: ./
+          token: ${{ secrets.OSPO_TOKEN }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          licenseAllowlist: "0bsd\napache-2.0\nmit"
+          repo: roadie-backstage-plugins
+          owner: RoadieHQ
+          org: wayfair-contribs
+          user: lelia
+          addUser: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,16 +21,12 @@ jobs:
       - run: |
           npm run all
 
-##############################################################################
-# Integration tests temporarily disabled while token access issue is diagnosed
-##############################################################################
-
   test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: ./
-        name: "🚀 test github user workflow"
+      - name: "🚀 test github user workflow"
+        uses: ./
         with:
           path: ./
           token: ${{ secrets.ACCESS_TOKEN }}
@@ -38,11 +34,11 @@ jobs:
           repo: tremor-runtime
           owner: tremor-rs
           user: lelia
-      - uses: ./
-        name: "🌎 test github org workflow"
+      - name: "🌎 test github org workflow"
+        uses: ./
         with:
           path: ./
-          token: ${{ secrets.OSPO_TOKEN }}
+          token: ${{ secrets.ACCESS_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
           licenseAllowlist: "0bsd\napache-2.0\nmit"
           repo: roadie-backstage-plugins

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         name: "🚀 test github user workflow"
         with:
           path: ./
-          token: ${{ secrets.DROWE_ACCESS_TOKEN }}
+          token: ${{ secrets.ACCESS_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
           repo: tremor-runtime
           owner: tremor-rs


### PR DESCRIPTION
Restores integration tests after procuring a new access token due to org transfer.