### PR TITLE
Using service account for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repo: tremor-runtime
           owner: tremor-rs
-          user: lelia
+          user: lhasa-ospo
       - name: "🌎 test github org workflow"
         uses: ./
         with:
@@ -44,5 +44,5 @@ jobs:
           repo: roadie-backstage-plugins
           owner: RoadieHQ
           org: wayfair-contribs
-          user: lelia
+          user: lhasa-ospo
           addUser: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,7 @@ name: Tests
 
 on: # Rebuild any PRs and main branch changes
 
+  pull_request_target:
   pull_request:
   push:
     branches:


### PR DESCRIPTION
* Uses `lhasa-ospo` service account for performing integration tests
* Adds the `pull_request_target` event trigger to GitHub workflow