### PR TITLE
Add schedule + dependency grouping to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,47 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Renovate configuration recommended by the Wayfair OSPO",
+  "labels": [
+    "renovate/{{depName}}"
+  ],
   "extends": [
-    "config:base"
+    "config:base",
+    ":rebaseStalePrs"
+  ],
+  "schedule": [
+    "before 3am every weekday"
+  ],
+  "enabledManagers": [
+    "github-actions",
+    "npm"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin"]
+    },
+    {
+      "matchPackageNames": ["jest", "ts-jest", "@types/jest"],
+      "matchPackagePrefixes": ["jest-"],
+      "groupName": "Jest"
+    },
+    {
+      "matchPackageNames": ["eslint"],
+      "matchPackagePrefixes": ["eslint-", "@typescript-eslint/"],
+      "groupName": "ESLint"
+    },
+    {
+      "matchPackageNames": ["@types/node"],
+      "groupName": "Node",
+      "allowedVersions": "17.x"
+    },
+    {
+      "matchPackageNames": ["typescript"],
+      "groupName": "TypeScript",
+      "allowedVersions": "4.x"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    }
   ]
 }


### PR DESCRIPTION
## Description

Configuring Renovate (`renovate.json`) for use with Node, TypeScript + GitHub Actions on a regular schedule.

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/forker/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
