### PR TITLE
Add config validator step for renovate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,12 +7,19 @@ on: # Rebuild any PRs and main branch changes
   pull_request_target:
 
 jobs:
-  lint:
+  markdown:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: 🧹 lint
+      - name: ⬇️ lint markdown files
         uses: avto-dev/markdown-lint@v1
         with:
           config: '.markdownlint.json'
-          args: '**/*.md .github/**/*.md'
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: 🧼 lint renovate config
+      - uses: suzuki-shunsuke/github-action-renovate-config-validator@v0.1.2
+        with:
+          config_file_path: renovate.json

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,6 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-
     steps:
     - uses: actions/stale@v5
       with:


### PR DESCRIPTION
## Description

Adds the GitHub Action `renovate-config-validator` to validate `renovate.json` configuration changes.

Runs in parallel to `markdown-lint` action during the `lint.yml` GitHub Workflow: https://github.com/wayfair-incubator/forker/actions/workflows/lint.yml

## Type of Change

- [ ] Bug Fix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](https://github.com/wayfair-incubator/forker/blob/main/CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
